### PR TITLE
fix: ensure custom page logo loads

### DIFF
--- a/src/custom-page/custom-page.controller.ts
+++ b/src/custom-page/custom-page.controller.ts
@@ -260,7 +260,7 @@ export class CustomPageController {
               const [ghlUser, setGhlUser] = useState({ name: 'Loading...', email: 'Loading...', hasTokens: false }); 
               const [editingInstanceId, setEditingInstanceId] = useState(null); 
               const [editingCustomName, setEditingCustomName] = useState('');
-              const [appLogo, setAppLogo] = useState('/public/LogoIcon.jpg');
+              const [appLogo, setAppLogo] = useState('/LogoIcon.jpg');
               const [appName, setAppName] = useState('WLink');
               const [theme, setTheme] = useState('dark');
 
@@ -692,7 +692,7 @@ export class CustomPageController {
                               src={appLogo} 
                               alt="App Logo" 
                               className="h-10 w-10 rounded-full"
-                              onError={(e) => { e.currentTarget.src = '/public/LogoIcon.jpg'; }}
+                              onError={(e) => { e.currentTarget.src = '/LogoIcon.jpg'; }}
                             />
                         </div>
                         <div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ async function bootstrap() {
   // === Servir archivos estáticos ===
   // Sirve {projectRoot}/public en la RAÍZ del dominio.
   // Ej.: public/LogoIcon.png -> https://tu-dominio/LogoIcon.png
-  app.useStaticAssets(join(__dirname, '..', 'public'));
+  app.useStaticAssets(join(process.cwd(), 'public'));
 
   // === Configuración existente ===
   app.use(json({ limit: '1mb' }));


### PR DESCRIPTION
## Summary
- serve public assets from process cwd so LogoIcon.jpg resolves at domain root

## Testing
- `npm test`
- `npm run build`
- `curl -I http://localhost:3000/LogoIcon.jpg`


------
https://chatgpt.com/codex/tasks/task_e_68a8dea8ac108322975548c25aee1677